### PR TITLE
✨ (Concrete): Remove Tinted Tiles Hidden Tag

### DIFF
--- a/utils/concrete_tinter.lua
+++ b/utils/concrete_tinter.lua
@@ -68,6 +68,8 @@ function ConcreteTinter.Tint(concrete_type, color)
     end
     tinted_tile.minable.result = tinted_tile.name
 
+    -- Now that these tiles are accessible there is no need for them to be hidden
+    tinted_tile.hidden = false
 
     -- Setting up item
     local tinted_item = ConcreteTinter.MakeItem(


### PR DESCRIPTION
Now that the tinted concrete tiles are able to be crafted, mined, and placed in a blueprint there is no need for them to stay hidden.

This allows other parts of the API to discover them.  
For example, they now appear as options in GUI 'choose-elem-button' options when filtered to Tiles.

-----------
I attempted to follow your commit style.